### PR TITLE
Clarification about apostrophes

### DIFF
--- a/02_iCommands_Handson_User-Training.md
+++ b/02_iCommands_Handson_User-Training.md
@@ -144,6 +144,10 @@ The following would print the contents of the file test1 to the terminal:
 istream read test1
 ```
 
+>   
+> **Warning:** Currently, the `istream` command is not working in our iRODS zones.
+> 
+
 ### Functional iCommands
 With the commands in this section, we will do functional data operations like data uploading/downloading, access control and verifying/synchronizing data.
 This constitutes the basis of data management in iRODS.


### PR DESCRIPTION
- It appears you have to provide the apostrophes when irule prompts for a string
- small typo